### PR TITLE
Require fog-aws gem instead of fog

### DIFF
--- a/lib/propono/components/sns.rb
+++ b/lib/propono/components/sns.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 
 module Propono
   module Sns

--- a/lib/propono/components/sqs.rb
+++ b/lib/propono/components/sqs.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 
 module Propono
   module Sqs

--- a/propono.gemspec
+++ b/propono.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-aws", "~> 0.0"
+  spec.add_dependency "fog-aws"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/propono.gemspec
+++ b/propono.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog", "~> 1.15"
+  spec.add_dependency "fog-aws", "~> 0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,7 @@ class Minitest::Test
   end
 end
 
-require 'fog'
+require 'fog/aws'
 class Fog::AWS::SNS::Mock
   def create_topic(*args)
     foo = Object.new


### PR DESCRIPTION
The fog gem is pretty heavy considering it requires ~22 direct gem dependencies, which each have their own dependencies.  Since this is only using gem/aws (having only 4 direct dependencies), it makes sense to only require that gem instead.